### PR TITLE
Use optimistic StampedLock read instead of synchronized block in FastChunkProviderMixin

### DIFF
--- a/src/main/java/com/jozufozu/flywheel/mixin/FastChunkProviderMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/FastChunkProviderMixin.java
@@ -1,8 +1,8 @@
 package com.jozufozu.flywheel.mixin;
 
-import org.spongepowered.asm.mixin.Final;
+import java.util.concurrent.locks.StampedLock;
+
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -13,9 +13,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import com.jozufozu.flywheel.backend.Backend;
 
 import net.minecraft.client.multiplayer.ClientChunkProvider;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.biome.BiomeContainer;
 import net.minecraft.world.chunk.AbstractChunkProvider;
 import net.minecraft.world.chunk.Chunk;
@@ -25,25 +25,26 @@ import net.minecraft.world.chunk.IChunk;
 @Mixin(ClientChunkProvider.class)
 public abstract class FastChunkProviderMixin extends AbstractChunkProvider {
 
-	@Shadow
-	@Final
-	private ClientWorld level;
 	@Unique
-	private int lastX;
+	private final StampedLock lastChunkLock = new StampedLock();
 	@Unique
-	private int lastZ;
-
+	private volatile long lastChunkPos;
 	@Unique
-	private IChunk lastChunk;
+	private volatile IChunk lastChunk;
 
 	@Inject(method = "getChunk",
 			at = @At("HEAD"),
 			cancellable = true)
 	public void returnCachedChunk(int x, int z, ChunkStatus status, boolean create, CallbackInfoReturnable<IChunk> cir) {
 		if (Backend.getInstance().chunkCachingEnabled && status.isOrAfter(ChunkStatus.FULL)) {
-			synchronized (level) {
-				if (lastChunk != null && x == lastX && z == lastZ) {
-					cir.setReturnValue(lastChunk);
+			StampedLock lock = lastChunkLock;
+			long stamp = lock.tryOptimisticRead();
+			if (stamp != 0) {
+				if (ChunkPos.asLong(x, z) == lastChunkPos) {
+					IChunk chunk = lastChunk;
+					if (chunk != null && lock.validate(stamp)) {
+						cir.setReturnValue(chunk);
+					}
 				}
 			}
 		}
@@ -53,10 +54,12 @@ public abstract class FastChunkProviderMixin extends AbstractChunkProvider {
 			at = @At("RETURN"))
 	public void cacheChunk(int x, int z, ChunkStatus status, boolean create, CallbackInfoReturnable<IChunk> cir) {
 		if (Backend.getInstance().chunkCachingEnabled && status.isOrAfter(ChunkStatus.FULL)) {
-			synchronized (level) {
+			StampedLock lock = lastChunkLock;
+			long stamp = lock.tryWriteLock();
+			if (stamp != 0) {
+				lastChunkPos = ChunkPos.asLong(x, z);
 				lastChunk = cir.getReturnValue();
-				lastX = x;
-				lastZ = z;
+				lock.unlockWrite(stamp);
 			}
 		}
 	}
@@ -64,26 +67,38 @@ public abstract class FastChunkProviderMixin extends AbstractChunkProvider {
 	@Inject(method = "drop", at = @At("HEAD"))
 	public void invalidateOnDrop(int x, int z, CallbackInfo ci) {
 		if (Backend.getInstance().chunkCachingEnabled) {
-			synchronized (level) {
-				if (x == lastX && z == lastZ) lastChunk = null;
+			StampedLock lock = lastChunkLock;
+			long stamp = lock.writeLock();
+			if (ChunkPos.asLong(x, z) == lastChunkPos) {
+				lastChunk = null;
 			}
+			lock.unlockWrite(stamp);
 		}
 	}
 
 	@Inject(method = "replaceWithPacketData", at = @At("HEAD"))
 	public void invalidateOnPacket(int x, int z, BiomeContainer p_228313_3_, PacketBuffer p_228313_4_, CompoundNBT p_228313_5_, int p_228313_6_, boolean p_228313_7_, CallbackInfoReturnable<Chunk> cir) {
 		if (Backend.getInstance().chunkCachingEnabled) {
-			synchronized (level) {
-				if (x == lastX && z == lastZ) lastChunk = null;
+			StampedLock lock = lastChunkLock;
+			long stamp = lock.writeLock();
+			if (ChunkPos.asLong(x, z) == lastChunkPos) {
+				lastChunk = null;
 			}
+			lock.unlockWrite(stamp);
 		}
 	}
 
 	@Redirect(method = "isTickingChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/ClientChunkProvider;hasChunk(II)Z"))
 	public boolean redirectTicking(ClientChunkProvider clientChunkProvider, int x, int z) {
 		if (Backend.getInstance().chunkCachingEnabled) {
-			synchronized (level) {
-				if (lastChunk != null && x == lastX && z == lastZ) return true;
+			StampedLock lock = lastChunkLock;
+			long stamp = lock.tryOptimisticRead();
+			if (stamp != 0) {
+				if (ChunkPos.asLong(x, z) == lastChunkPos && lastChunk != null) {
+					if (lock.validate(stamp)) {
+						return true;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
This currently causes a fair level of slowdown during rendering due to the locking cost, measuring around ~10% of render thread time in some cases. I'm not sure if caching chunks here is the best solution to performance issues here- it may be more worth looking into optimising the underlying implementation for retrieving chunks such as by avoiding the `floorMod`s, but I am not sure if that is much in scope here.
This should regardless however be a significant improvement over synchronizing.