### PR TITLE
Make VirtualEmptyBlockGetter.lightEngine::getLevel return null

### DIFF
--- a/src/main/java/com/jozufozu/flywheel/util/VirtualEmptyBlockGetter.java
+++ b/src/main/java/com/jozufozu/flywheel/util/VirtualEmptyBlockGetter.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ColorResolver;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
@@ -33,7 +34,7 @@ public enum VirtualEmptyBlockGetter implements BlockAndTintGetter {
 
 		@Override
 		public BlockGetter getLevel() {
-			return VirtualEmptyBlockGetter.this;
+			return null;
 		}
 	}, false, false) {
 		private static final LayerLightEventListener SKY_DUMMY_LISTENER = new LayerLightEventListener() {


### PR DESCRIPTION
This is for the sake of compatibility with Starlight, and with anything else that would expect that the LightChunkGetter passed to the LevelLightEngine constructor should return a Level from its getLevel method.

Tested and seems to only solve problems, not create any.