### PR TITLE
Fix Linux issue with Mesa

### DIFF
--- a/src/main/resources/assets/flywheel/flywheel/shaders/context/world.glsl
+++ b/src/main/resources/assets/flywheel/flywheel/shaders/context/world.glsl
@@ -1,5 +1,12 @@
 #use "flywheel:context/fog.glsl"
 
+// optimize discard usage
+#if defined(ALPHA_DISCARD)
+#if defined(GL_ARB_conservative_depth)
+layout (depth_greater) out float gl_FragDepth;
+#endif
+#endif
+
 uniform float uTime;
 uniform mat4 uViewProjection;
 uniform vec3 uCameraPos;
@@ -25,12 +32,7 @@ void FLWFinalizeWorldPos(inout vec4 worldPos) {
 #use "flywheel:core/lightutil.glsl"
 
 #define ALPHA_DISCARD 0.1
-// optimize discard usage
-#if defined(ALPHA_DISCARD)
-#if defined(GL_ARB_conservative_depth)
-layout (depth_greater) out float gl_FragDepth;
-#endif
-#endif
+
 out vec4 fragColor;
 
 vec4 FLWBlockTexture(vec2 texCoords) {


### PR DESCRIPTION
This likely fixes #74, #72 and #68 based on the crash logs.

The `#extension` directive seems to get included in the middle of the shader file and needs to be included at the top of the file; this commit moves it to the top of the file and appears to work with a similar pull request I'm making for Create.

From some rudimentary Google searches, it seems like many Windows and Mac drivers are more accepting of this, but that Mesa and other drivers more strictly follow the OpenGL specification, and thus fail to compile the code. I have not actually confirmed this, but I have confirmed that updating this and Create makes it work on my system.