### PR TITLE
Change environment to * for Fabric

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "icon": "logo.png",
 
-  "environment": "client",
+  "environment": "*",
   "entrypoints": {
     "client": [
       "com.jozufozu.flywheel.FlywheelClient"


### PR DESCRIPTION
Flywheel has classes that are referenced from code which is loaded on both sides such as `LightListener`. The environment of Flywheel Fabric is currently set to `client` which means it will not be loaded on the dedicated server, which causes ClassNotFoundException's.