### PR TITLE
Switch to the block vertex format for instancing

### DIFF
--- a/src/main/java/com/jozufozu/flywheel/backend/instancing/instancing/InstancedMaterialGroup.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/instancing/instancing/InstancedMaterialGroup.java
@@ -94,7 +94,7 @@ public class InstancedMaterialGroup<P extends WorldProgram> implements MaterialG
 			if (material.nothingToRender()) continue;
 
 			P program = owner.context.getProgram(ProgramContext.create(entry.getKey()
-					.getProgramSpec(), Formats.POS_TEX_NORMAL, layer));
+					.getProgramSpec(), Formats.BLOCK, layer));
 
 			// XXX Shader is bound and not reset or restored
 			program.bind();
@@ -155,7 +155,7 @@ public class InstancedMaterialGroup<P extends WorldProgram> implements MaterialG
 				.onAMDWindows()) {
 			return FallbackAllocator.INSTANCE;
 		} else {
-			return new ModelPool(Formats.POS_TEX_NORMAL);
+			return new ModelPool(Formats.BLOCK);
 		}
 	}
 }

--- a/src/main/java/com/jozufozu/flywheel/backend/model/FallbackAllocator.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/model/FallbackAllocator.java
@@ -8,7 +8,7 @@ public enum FallbackAllocator implements ModelAllocator {
 
 	@Override
 	public BufferedModel alloc(Model model, Callback allocationCallback) {
-		IndexedModel out = new IndexedModel(model, Formats.POS_TEX_NORMAL);
+		IndexedModel out = new IndexedModel(model, Formats.BLOCK);
 		allocationCallback.onAlloc(out);
 		return out;
 	}


### PR DESCRIPTION
This switches to the block format for instancing instead of the PosTexNorm variant, allowing for more flexibility in the models that are used during instancing.

I tested this as far as I could and it seems to work properly.

Do you guys want PRs for the other game verions and fabric as well, or how does porting work?
Closes: #161 