### PR TITLE
Add Sodium Fabric 1.20.1-0.5.3 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     // Fabric API
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 
-    modCompileOnly 'maven.modrinth:sodium:mc1.20-0.4.10'
+    modCompileOnly 'maven.modrinth:sodium:mc1.20.1-0.5.3'
     modCompileOnly 'maven.modrinth:iris:1.6.4+1.20'
 
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/src/main/java/com/jozufozu/flywheel/fabric/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/fabric/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
@@ -8,14 +8,14 @@ import com.jozufozu.flywheel.backend.Backend;
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderRegistry;
 
-import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderRebuildTask;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderMeshingTask;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(value = ChunkRenderRebuildTask.class, remap = false)
-public class ChunkRenderRebuildTaskMixin {
-	@Redirect(method = "performBuild", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderDispatcher;getRenderer(Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;", remap = true))
+@Mixin(value = ChunkBuilderMeshingTask.class, remap = false)
+public class ChunkBuilderMeshingTaskMixin {
+	@Redirect(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderDispatcher;getRenderer(Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;", remap = true))
 	private BlockEntityRenderer<?> redirectGetRenderer(BlockEntityRenderDispatcher dispatcher, BlockEntity blockEntity) {
 		if (Backend.canUseInstancing(blockEntity.getLevel())) {
 			if (InstancedRenderRegistry.canInstance(blockEntity.getType()))

--- a/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/SodiumChunkRenderDataMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/SodiumChunkRenderDataMixin.java
@@ -14,11 +14,11 @@ import com.jozufozu.flywheel.backend.Backend;
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderRegistry;
 
-import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData;
+import me.jellysquid.mods.sodium.client.render.chunk.data.BuiltSectionInfo;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(targets = "me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderData$Builder", remap = false)
+@Mixin(targets = "me.jellysquid.mods.sodium.client.render.chunk.data.BuiltSectionInfo$Builder", remap = false)
 public class SodiumChunkRenderDataMixin {
 
 	@Unique
@@ -51,7 +51,7 @@ public class SodiumChunkRenderDataMixin {
 	}
 
 	@Inject(method = "build", at = @At("HEAD"))
-	private void flywheel$onBuild(CallbackInfoReturnable<ChunkRenderData> cir) {
+	private void flywheel$onBuild(CallbackInfoReturnable<BuiltSectionInfo> cir) {
 		if (flywheel$level == null || flywheel$blockEntities == null || !Backend.canUseInstancing(flywheel$level)) {
 			return;
 		}

--- a/src/main/resources/flywheel.sodium.mixins.json
+++ b/src/main/resources/flywheel.sodium.mixins.json
@@ -5,7 +5,7 @@
   "plugin": "com.jozufozu.flywheel.fabric.mixin.sodium.SodiumMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "client": [
-    "ChunkRenderRebuildTaskMixin"
+    "ChunkBuilderMeshingTaskMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
I tested my changes with Sodium (```sodium-fabric-mc1.20.1-0.5.3.jar```) and Indium (```indium-1.0.27+mc1.20.1.jar```) by renaming the resulting ```flywheel-fabric-1.20.1-0.6.9.jar``` to ```flywheel-fabric-1.20.1-0.6.9-1.jar``` and putting it in the newest Create-Fabric.jar (```create-fabric-0.5.1-d-build.1161+mc1.20.1.jar```) under META-INF/jars, replacing the existing one and removing the "breaks sodium 0.5.0" entry from "fabric.mod.json" inside the Create-Fabric.jar.   

I tested it with my Create modpack too and got no crashes or graphical glitches/artifacts and alike.