### PR TITLE
Update Fabric to 1.20.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,6 +84,7 @@ body:
             label: Minecraft Version
             description: The version of Minecraft you were using when the bug occured
             options:
+                - "1.20.2"
                 - "1.20.1"
                 - "1.19.2"
                 - "1.18.2"

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,6 @@ curseforge {
         changelog = file('changelog.txt')
         releaseType = project.curse_type
         mainArtifact jar
-        addGameVersion '1.20.1'
+        addGameVersion '1.20.2'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs = -Xmx3G
 org.gradle.daemon = false
 # mod version info
 mod_version = 0.6.10
-artifact_minecraft_version = 1.20.1
+artifact_minecraft_version = 1.20.2
 
 minecraft_version = 1.20.2
 loader_version = 0.14.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.daemon = false
 mod_version = 0.6.10
 artifact_minecraft_version = 1.20.1
 
-minecraft_version = 1.20.1
-loader_version = 0.14.21
-fabric_version = 0.90.0+1.20.1
+minecraft_version = 1.20.2
+loader_version = 0.14.22
+fabric_version = 0.91.0+1.20.2
 
 # build dependency versions
 loom_version = 1.4-SNAPSHOT

--- a/src/main/java/com/jozufozu/flywheel/fabric/mixin/MinecraftMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/fabric/mixin/MinecraftMixin.java
@@ -24,7 +24,7 @@ public abstract class MinecraftMixin {
 		}
 	}
 
-	@Inject(method = "clearLevel(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At(value = "JUMP", opcode = Opcodes.IFNULL, ordinal = 2))
+	@Inject(method = "disconnect(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At(value = "JUMP", opcode = Opcodes.IFNULL, ordinal = 2))
 	private void onClearLevel(CallbackInfo ci) {
 		ForgeEvents.unloadWorld(level);
 	}

--- a/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
@@ -41,7 +41,7 @@ public class LevelRendererMixin {
 		FlywheelEvents.BEGIN_FRAME.invoker().handleEvent(new BeginFrameEvent(level, camera, frustum));
 	}
 
-	@Inject(at = @At("TAIL"), method = "renderChunkLayer")
+	@Inject(at = @At("TAIL"), method = "renderSectionLayer")
 	private void renderLayer(RenderType type, PoseStack stack, double camX, double camY, double camZ, Matrix4f projection, CallbackInfo ci) {
 		FlywheelEvents.RENDER_LAYER.invoker().handleEvent(new RenderLayerEvent(level, type, stack, renderBuffers, camX, camY, camZ));
 	}

--- a/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/ChunkRebuildHooksMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/ChunkRebuildHooksMixin.java
@@ -10,9 +10,9 @@ import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(targets = "net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$RenderChunk$RebuildTask")
+@Mixin(targets = "net.minecraft.client.renderer.chunk.SectionRenderDispatcher$RenderSection$RebuildTask")
 public class ChunkRebuildHooksMixin {
-	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/SectionRenderDispatcher$RenderSection$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
 	private void flywheel$tryAddBlockEntity(@Coerce Object compileResults, BlockEntity blockEntity, CallbackInfo ci) {
 		if (InstancedRenderDispatcher.tryAddBlockEntity(blockEntity)) {
 			ci.cancel();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": ">=0.84.0",
-    "minecraft": ">=1.20.1",
+    "minecraft": ">=1.20.2",
     "java": ">=17"
   },
   "breaks": {


### PR DESCRIPTION
I updated the fabric dependencies to 1.20.2 and fixed all mixins that jumped into Minecraft classes/methods that were renamed.

To test this, I ran the runClient gradle task and was able to play normally.
Is there anything else I should do to test this?