### PR TITLE
Update to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,11 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
-    mappings channel: 'parchment', version: "${parchment_version}-${minecraft_version}"
+    mappings channel: 'official', version: "${minecraft_version}" // Parchment 1.20.4 isn't available yet
 
     copyIdeResources = true
+
+    accessTransformer = file("src/main/resources/META-INF/accesstransformer.cfg")
 
     runs {
         configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
-    mappings channel: 'official', version: "${minecraft_version}" // Parchment 1.20.4 isn't available yet
+    mappings channel: 'parchment', version: "${parchment_version}-${minecraft_version}"
 
     copyIdeResources = true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ mixingradle_version = 0.7.+
 mixin_version = 0.8.5
 librarian_version = 1.+
 cursegradle_version = 1.4.0
-parchment_version = 2023.09.03
+parchment_version = 2024.02.25

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.daemon = false
 # mod version info
 mod_version = 1.0.0-alpha
 artifact_minecraft_version = 1.20.1
-minecraft_version = 1.20.1
-forge_version = 47.2.19
+minecraft_version = 1.20.4
+forge_version = 49.0.30
 # Version ranges for the mods.toml
-minecraft_version_range = [1.20.1,1.20.2)
-forge_version_range = [47,)
-loader_version_range = [47,)
+minecraft_version_range = [1.20.4,1.20.5)
+forge_version_range = [49,)
+loader_version_range = [49,)
 
 # build dependency versions
 forgegradle_version = [6.0.16,6.2)

--- a/src/main/java/com/jozufozu/flywheel/Flywheel.java
+++ b/src/main/java/com/jozufozu/flywheel/Flywheel.java
@@ -146,7 +146,7 @@ public class Flywheel {
 	private static void addDebugInfo(CustomizeGuiOverlayEvent.DebugText event) {
 		Minecraft mc = Minecraft.getInstance();
 
-		if (!mc.options.renderDebug) {
+		if (!mc.getDebugOverlay().showDebugScreen()) {
 			return;
 		}
 

--- a/src/main/java/com/jozufozu/flywheel/impl/mixin/LevelRendererMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/impl/mixin/LevelRendererMixin.java
@@ -103,7 +103,7 @@ abstract class LevelRendererMixin {
 		flywheel$dispatch(RenderStage.AFTER_TRANSLUCENT_TERRAIN);
 	}
 
-	@Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;renderChunkLayer(Lnet/minecraft/client/renderer/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;DDDLorg/joml/Matrix4f;)V", ordinal = 6, shift = Shift.AFTER))
+	@Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;renderSectionLayer(Lnet/minecraft/client/renderer/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;DDDLorg/joml/Matrix4f;)V", ordinal = 6, shift = Shift.AFTER))
 	private void flywheel$onStage$afterTranslucentTerrain(CallbackInfo ci) {
 		flywheel$dispatch(RenderStage.AFTER_TRANSLUCENT_TERRAIN);
 	}

--- a/src/main/java/com/jozufozu/flywheel/impl/mixin/MinecraftMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/impl/mixin/MinecraftMixin.java
@@ -1,7 +1,6 @@
 package com.jozufozu.flywheel.impl.mixin;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,11 +10,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.jozufozu.flywheel.api.event.EndClientResourceReloadEvent;
-import com.mojang.realmsclient.client.RealmsClient;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.main.GameConfig;
-import net.minecraft.server.packs.resources.ReloadInstance;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraftforge.fml.ModLoader;
 
@@ -26,12 +22,12 @@ abstract class MinecraftMixin {
 	private ReloadableResourceManager resourceManager;
 
 	@Inject(method = "lambda$new$5", at = @At("HEAD"))
-	private void flywheel$onEndInitialResourceReload(RealmsClient realmsClient, ReloadInstance reloadInstance, GameConfig gameConfig, Optional<Throwable> error, CallbackInfo ci) {
-		ModLoader.get().postEvent(new EndClientResourceReloadEvent((Minecraft) (Object) this, resourceManager, true, error));
+	private void flywheel$onEndInitialResourceReload(Minecraft.GameLoadCookie minecraft$gameloadcookie, Throwable error, CallbackInfo ci) {
+		ModLoader.get().postEvent(new EndClientResourceReloadEvent((Minecraft) (Object) this, resourceManager, true, Optional.ofNullable(error)));
 	}
 
-	@Inject(method = "lambda$reloadResourcePacks$28", at = @At("HEAD"))
-	private void flywheel$onEndManualResourceReload(boolean recovery, CompletableFuture<Void> future, Optional<Throwable> error, CallbackInfo ci) {
-		ModLoader.get().postEvent(new EndClientResourceReloadEvent((Minecraft) (Object) this, resourceManager, false, error));
+	@Inject(method = "lambda$reloadResourcePacks$34", at = @At("HEAD"))
+	private void flywheel$onEndManualResourceReload(boolean p_168020_, Minecraft.GameLoadCookie p_300647_, Throwable error, CallbackInfo ci) {
+		ModLoader.get().postEvent(new EndClientResourceReloadEvent((Minecraft) (Object) this, resourceManager, false, Optional.ofNullable(error)));
 	}
 }

--- a/src/main/java/com/jozufozu/flywheel/impl/mixin/visualmanage/RebuildTaskMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/impl/mixin/visualmanage/RebuildTaskMixin.java
@@ -10,9 +10,9 @@ import com.jozufozu.flywheel.impl.visualization.VisualizationHelper;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(targets = "net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$RenderChunk$RebuildTask")
+@Mixin(targets = "net.minecraft.client.renderer.chunk.SectionRenderDispatcher$RenderSection$RebuildTask")
 abstract class RebuildTaskMixin {
-	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/SectionRenderDispatcher$RenderSection$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
 	private void flywheel$tryAddBlockEntity(@Coerce Object compileResults, BlockEntity blockEntity, CallbackInfo ci) {
 		if (VisualizationHelper.tryAddBlockEntity(blockEntity)) {
 			ci.cancel();

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.client.Minecraft$GameLoadCookie


### PR DESCRIPTION
This PR aims to update flywheel to Forge 1.20.4, but unfortunately I have not been able to get it to work 100% yet.

The code compiles without any errors, but when starting the client it shows the error `java.lang.VerifyError: Bad type on operand stack`: https://mclo.gs/AWe0wVs#L79

The details on this error message say `Type 'com/jozufozu/flywheel/api/event/EndClientResourceReloadEvent' (current frame, stack[1]) is not assignable to 'net/minecraftforge/eventbus/api/Event'`, but this does not make sense, as EndClientResourceReloadEvent directly extends that class.

Any help with this issue would be much appreciated.