### PR TITLE
Update Fabric to 1.20.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,6 +84,7 @@ body:
             label: Minecraft Version
             description: The version of Minecraft you were using when the bug occured
             options:
+                - "1.20.2"
                 - "1.20.1"
                 - "1.19.2"
                 - "1.18.2"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,7 +84,7 @@ body:
             label: Minecraft Version
             description: The version of Minecraft you were using when the bug occured
             options:
-                - "1.20.2"
+                - "1.20.4"
                 - "1.20.1"
                 - "1.19.2"
                 - "1.18.2"

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,6 @@ curseforge {
         changelog = file('changelog.txt')
         releaseType = project.curse_type
         mainArtifact jar
-        addGameVersion '1.20.1'
+        addGameVersion '1.20.2'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,6 @@ curseforge {
         changelog = file('changelog.txt')
         releaseType = project.curse_type
         mainArtifact jar
-        addGameVersion '1.20.2'
+        addGameVersion '1.20.4'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs = -Xmx3G
 org.gradle.daemon = false
 # mod version info
 mod_version = 0.6.10
-artifact_minecraft_version = 1.20.1
+artifact_minecraft_version = 1.20.2
 
 minecraft_version = 1.20.2
 loader_version = 0.14.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.daemon = false
 mod_version = 0.6.10
 artifact_minecraft_version = 1.20.1
 
-minecraft_version = 1.20.1
-loader_version = 0.14.21
-fabric_version = 0.90.0+1.20.1
+minecraft_version = 1.20.2
+loader_version = 0.14.22
+fabric_version = 0.91.0+1.20.2
 
 # build dependency versions
 loom_version = 1.4-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs = -Xmx3G
 org.gradle.daemon = false
 # mod version info
 mod_version = 0.6.10
-artifact_minecraft_version = 1.20.2
+artifact_minecraft_version = 1.20.4
 
-minecraft_version = 1.20.2
-loader_version = 0.14.22
-fabric_version = 0.91.0+1.20.2
+minecraft_version = 1.20.4
+loader_version = 0.15.7
+fabric_version = 0.96.4+1.20.4
 
 # build dependency versions
-loom_version = 1.4-SNAPSHOT
+loom_version = 1.5-SNAPSHOT
 cursegradle_version = 1.4.0
 parchment_version = 2023.06.25
 

--- a/src/main/java/com/jozufozu/flywheel/core/virtual/VirtualRenderWorld.java
+++ b/src/main/java/com/jozufozu/flywheel/core/virtual/VirtualRenderWorld.java
@@ -21,6 +21,7 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.TickRateManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -324,6 +325,11 @@ public class VirtualRenderWorld extends Level implements FlywheelWorld {
 	@Override
 	public FeatureFlagSet enabledFeatures() {
 		return level.enabledFeatures();
+	}
+
+	@Override
+	public TickRateManager tickRateManager() {
+		return level.tickRateManager();
 	}
 
 	// ADDITIONAL OVERRRIDES

--- a/src/main/java/com/jozufozu/flywheel/fabric/mixin/MinecraftMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/fabric/mixin/MinecraftMixin.java
@@ -24,7 +24,7 @@ public abstract class MinecraftMixin {
 		}
 	}
 
-	@Inject(method = "clearLevel(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At(value = "JUMP", opcode = Opcodes.IFNULL, ordinal = 2))
+	@Inject(method = "disconnect(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At(value = "JUMP", opcode = Opcodes.IFNULL, ordinal = 2))
 	private void onClearLevel(CallbackInfo ci) {
 		ForgeEvents.unloadWorld(level);
 	}

--- a/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
@@ -41,7 +41,7 @@ public class LevelRendererMixin {
 		FlywheelEvents.BEGIN_FRAME.invoker().handleEvent(new BeginFrameEvent(level, camera, frustum));
 	}
 
-	@Inject(at = @At("TAIL"), method = "renderChunkLayer")
+	@Inject(at = @At("TAIL"), method = "renderSectionLayer")
 	private void renderLayer(RenderType type, PoseStack stack, double camX, double camY, double camZ, Matrix4f projection, CallbackInfo ci) {
 		FlywheelEvents.RENDER_LAYER.invoker().handleEvent(new RenderLayerEvent(level, type, stack, renderBuffers, camX, camY, camZ));
 	}

--- a/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/ChunkRebuildHooksMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/ChunkRebuildHooksMixin.java
@@ -10,9 +10,9 @@ import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(targets = "net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$RenderChunk$RebuildTask")
+@Mixin(targets = "net.minecraft.client.renderer.chunk.SectionRenderDispatcher$RenderSection$RebuildTask")
 public class ChunkRebuildHooksMixin {
-	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/SectionRenderDispatcher$RenderSection$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
 	private void flywheel$tryAddBlockEntity(@Coerce Object compileResults, BlockEntity blockEntity, CallbackInfo ci) {
 		if (InstancedRenderDispatcher.tryAddBlockEntity(blockEntity)) {
 			ci.cancel();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": ">=0.84.0",
-    "minecraft": ">=1.20.1",
+    "minecraft": ">=1.20.2",
     "java": ">=17"
   },
   "breaks": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": ">=0.84.0",
-    "minecraft": ">=1.20.2",
+    "minecraft": ">=1.20.4",
     "java": ">=17"
   },
   "breaks": {


### PR DESCRIPTION
This PR updates the Fabric 1.20 branch to 1.20.4.
Compiling the project, starting a client and playing a single-player world were tested and worked without any issues.