### PR TITLE
Update to NeoForge 1.20.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,6 +96,7 @@ body:
             label: Minecraft Version
             description: The version of Minecraft you were using when the bug occured
             options:
+                - "1.20.4"
                 - "1.20.1"
                 - "1.19.2"
                 - "1.18.2"

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,6 @@ publishing {
             artifactId = archivesBaseName
 
             from components.java
-            //fg.component(it)
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,10 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.minecraftforge.net' }
-        mavenCentral()
-        maven { url = 'https://repo.spongepowered.org/repository/maven-public' }
-        maven { url = 'https://maven.parchmentmc.org' }
-    }
-    dependencies {
-        classpath "net.minecraftforge.gradle:ForgeGradle:${forgegradle_version}"
-        classpath "org.spongepowered:mixingradle:${mixingradle_version}"
-        classpath "org.parchmentmc:librarian:${librarian_version}"
-    }
-}
-
 plugins {
     id 'com.matthewprenger.cursegradle' version "${cursegradle_version}"
+    id 'net.neoforged.gradle.userdev' version '7.0.+'
+    id 'net.neoforged.gradle.mixin' version '7.0.+'
+    id 'maven-publish'
+    id 'eclipse'
 }
-apply plugin: 'net.minecraftforge.gradle'
-apply plugin: 'org.parchmentmc.librarian.forgegradle'
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
-apply plugin: 'org.spongepowered.mixin'
 
 boolean dev = System.getenv('RELEASE') == null || System.getenv('RELEASE').equalsIgnoreCase('false');
 
@@ -33,65 +18,41 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + ' (' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
-minecraft {
-    if (Boolean.parseBoolean(project.use_parchment)) {
-        mappings channel: 'parchment', version: "${parchment_version}-${minecraft_version}"
-    } else {
-        mappings channel: 'official', version: "${minecraft_version}"
+subsystems {
+    parchment {
+        enabled = Boolean.parseBoolean(project.use_parchment)
+        minecraftVersion = project.minecraft_version
+        mappingsVersion = project.parchment_version
+    }
+}
+
+runs {
+    configureEach {
+        workingDirectory project.file('run')
+
+        systemProperty 'forge.logging.console.level', 'debug'
+        systemProperty 'forge.logging.markers', 'REGISTRIES'
+
+        modSource project.sourceSets.main
     }
 
-    runs {
-        client {
-            workingDirectory project.file('run')
+    client {
+        systemProperty 'forge.logging.markers', ''
+        systemProperty 'mixin.debug.export', 'true'
+        systemProperty 'mixin.env.remapRefMap', 'true'
+        systemProperty 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+        systemProperty 'flw.loadRenderDoc', 'true'
+    }
 
-            property 'forge.logging.markers', ''
-            property 'forge.logging.console.level', 'debug'
-            property 'mixin.debug.export', 'true'
-            property 'mixin.env.remapRefMap', 'true'
-            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-            property 'flw.loadRenderDoc', 'true'
+    server {
+        programArgument 'nogui'
+    }
 
-            arg '-mixin.config=flywheel.mixins.json'
-            arg '-mixin.config=flywheel.sodium.mixins.json'
+    data {
+        systemProperty 'forge.logging.markers', 'REGISTRIES'
 
-            mods {
-                flywheel {
-                    source sourceSets.main
-                }
-            }
-        }
-
-        server {
-            workingDirectory project.file('run')
-
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-
-            arg '-mixin.config=flywheel.mixins.json'
-            arg '-mixin.config=flywheel.sodium.mixins.json'
-
-            mods {
-                flywheel {
-                    source sourceSets.main
-                }
-            }
-        }
-
-        data {
-            workingDirectory project.file('run')
-
-            property 'forge.logging.markers', 'REGISTRIES'
-            property 'forge.logging.console.level', 'debug'
-
-            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', 'flywheel', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-
-            mods {
-                flywheel {
-                    source sourceSets.main
-                }
-            }
-        }
+        // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
+        programArguments.addAll '--mod', 'flywheel', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
     }
 }
 
@@ -116,30 +77,21 @@ repositories {
 }
 
 dependencies {
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+    implementation "net.neoforged:neoforge:${neoforge_version}"
 
     // switch to implementation for debugging
-    compileOnly fg.deobf('maven.modrinth:starlight-forge:1.1.2+1.20')
+    implementation 'maven.modrinth:starlight-neoforge:1.1.3+1.20.4'
 
-    compileOnly fg.deobf('maven.modrinth:rubidium:0.7.0a')
-    compileOnly fg.deobf('maven.modrinth:oculus:1.20-1.6.4')
-
-    // https://discord.com/channels/313125603924639766/725850371834118214/910619168821354497
-    // Prevent Mixin annotation processor from getting into IntelliJ's annotation processor settings
-    // This allows 'Settings > Build, Execution, and Deployment > Build Tools > Gradle > Build and run using' set to IntelliJ to work correctly
-    if (!Boolean.getBoolean('idea.sync.active')) {
-        annotationProcessor "org.spongepowered:mixin:${mixin_version}:processor"
-    }
+    // Rubidium and Oculus don't support 1.20.4 yet
+    //compileOnly fg.deobf('maven.modrinth:rubidium:0.7.0a')
+    //compileOnly fg.deobf('maven.modrinth:oculus:1.20-1.6.4')
 }
 
 mixin {
-    add sourceSets.main, 'flywheel.refmap.json'
+    config 'flywheel.mixins.json'
+    //config 'flywheel.sodium.mixins.json'
 }
 
-// Workaround for SpongePowered/MixinGradle#38
-afterEvaluate {
-    tasks.configureReobfTaskForReobfJar.mustRunAfter(tasks.compileJava)
-}
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
@@ -177,8 +129,26 @@ void addLicense(jarTask) {
     }
 }
 
-jar.finalizedBy('reobfJar')
 addLicense(jar)
+
+// This block of code expands all declared replace properties in the specified resource targets.
+// A missing property will result in an error. Properties are expanded using ${} Groovy notation.
+// When "copyIdeResources" is enabled, this will also run before the game launches in IDE environments.
+// See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
+tasks.withType(ProcessResources).configureEach {
+    var replaceProperties = [
+            minecraft_version       : minecraft_version,
+            minecraft_version_range : minecraft_version_range,
+            neoforge_version_range  : neoforge_version_range,
+            loader_version_range    : loader_version_range,
+            mod_version             : mod_version,
+    ]
+    inputs.properties replaceProperties
+
+    filesMatching(['META-INF/mods.toml']) {
+        expand replaceProperties + [project: project]
+    }
+}
 
 publishing {
     publications {
@@ -186,7 +156,7 @@ publishing {
             artifactId = archivesBaseName
 
             from components.java
-            fg.component(it)
+            //fg.component(it)
         }
     }
 
@@ -209,6 +179,6 @@ curseforge {
         changelog = file('changelog.txt')
         releaseType = project.curse_type
         mainArtifact jar
-        addGameVersion '1.20.1'
+        addGameVersion '1.20.4'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,15 @@ org.gradle.daemon = false
 
 # mod version info
 mod_version = 0.6.10
-artifact_minecraft_version = 1.20.1
+artifact_minecraft_version = 1.20.4
 
-minecraft_version = 1.20.1
-forge_version = 47.0.34
+minecraft_version = 1.20.4
+neoforge_version = 20.4.80-beta
+
+# mods.toml info
+loader_version_range = [2,)
+minecraft_version_range = [1.20.4,1.21)
+neoforge_version_range = [20.4,)
 
 # build dependency versions
 forgegradle_version = 6.0.6
@@ -14,9 +19,9 @@ mixingradle_version = 0.7-SNAPSHOT
 mixin_version = 0.8.5
 librarian_version = 1.+
 cursegradle_version = 1.4.0
-parchment_version = 2023.06.25
+parchment_version = 2024.02.25
 
-use_parchment = false
+use_parchment = true
 
 # curseforge info
 projectId = 486392

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = 'https://maven.neoforged.net/releases' }
+    }
+}
+
 rootProject.name = 'Flywheel-Forge'

--- a/src/main/java/com/jozufozu/flywheel/Flywheel.java
+++ b/src/main/java/com/jozufozu/flywheel/Flywheel.java
@@ -1,5 +1,11 @@
 package com.jozufozu.flywheel;
 
+import net.neoforged.bus.api.IEventBus;
+
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.registries.RegisterEvent;
+
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.slf4j.Logger;
 
@@ -21,17 +27,10 @@ import net.minecraft.commands.synchronization.ArgumentTypeInfos;
 import net.minecraft.commands.synchronization.SingletonArgumentInfo;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.CrashReportCallables;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.IExtensionPoint;
-import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.network.NetworkConstants;
-import net.minecraftforge.registries.RegisterEvent;
+import net.neoforged.fml.CrashReportCallables;
+import net.neoforged.fml.IExtensionPoint;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.common.Mod;
 
 @Mod(Flywheel.ID)
 public class Flywheel {
@@ -40,7 +39,7 @@ public class Flywheel {
 	public static final Logger LOGGER = LogUtils.getLogger();
 	private static ArtifactVersion version;
 
-	public Flywheel() {
+	public Flywheel(IEventBus modEventBus) {
 		ModLoadingContext modLoadingContext = ModLoadingContext.get();
 
 		version = modLoadingContext
@@ -48,19 +47,19 @@ public class Flywheel {
 				.getModInfo()
 				.getVersion();
 
-		IEventBus forgeEventBus = MinecraftForge.EVENT_BUS;
-		IEventBus modEventBus = FMLJavaModLoadingContext.get()
-				.getModEventBus();
+		IEventBus forgeEventBus = NeoForge.EVENT_BUS;
 		modEventBus.addListener(Flywheel::registerArgumentTypes);
 
 		FlwConfig.init();
 
 		modLoadingContext.registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(
-				() -> NetworkConstants.IGNORESERVERONLY,
-				(serverVersion, isNetwork) -> isNetwork
+				() -> "FLYWHEEL",
+				(serverVersion, isNetwork) -> true
 		));
 
-		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> Flywheel.clientInit(forgeEventBus, modEventBus));
+		if (FMLEnvironment.dist.isClient()) {
+			Flywheel.clientInit(forgeEventBus, modEventBus);
+		}
 	}
 
 	private static void clientInit(IEventBus forgeEventBus, IEventBus modEventBus) {

--- a/src/main/java/com/jozufozu/flywheel/backend/Loader.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/Loader.java
@@ -29,7 +29,7 @@ import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
-import net.minecraftforge.fml.ModLoader;
+import net.neoforged.fml.ModLoader;
 
 /**
  * The main entity for loading shaders.

--- a/src/main/java/com/jozufozu/flywheel/backend/RenderWork.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/RenderWork.java
@@ -3,11 +3,11 @@ package com.jozufozu.flywheel.backend;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RenderLevelStageEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 
 @Mod.EventBusSubscriber(value = Dist.CLIENT)
 public class RenderWork {

--- a/src/main/java/com/jozufozu/flywheel/backend/ShadersModHandler.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/ShadersModHandler.java
@@ -6,10 +6,9 @@ import java.util.function.BooleanSupplier;
 
 import javax.annotation.Nullable;
 
-import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraftforge.fml.ModList;
+import net.neoforged.fml.ModList;
 
 public final class ShadersModHandler {
 	public static final String OPTIFINE_ROOT_PACKAGE = "net.optifine";
@@ -76,14 +75,14 @@ public final class ShadersModHandler {
 	private static class Oculus implements InternalHandler {
 		@Override
 		public boolean isShaderPackInUse() {
-			return IrisApi.getInstance()
-					.isShaderPackInUse();
+			return false /*IrisApi.getInstance()
+					.isShaderPackInUse()*/;
 		}
 
 		@Override
 		public boolean isRenderingShadowPass() {
-			return IrisApi.getInstance()
-					.isRenderingShadowPass();
+			return false /*IrisApi.getInstance()
+					.isRenderingShadowPass()*/;
 		}
 	}
 

--- a/src/main/java/com/jozufozu/flywheel/backend/gl/GlNumericType.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/gl/GlNumericType.java
@@ -10,8 +10,8 @@ import javax.annotation.Nullable;
 
 import org.lwjgl.opengl.GL11;
 
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public enum GlNumericType {

--- a/src/main/java/com/jozufozu/flywheel/backend/instancing/InstancedRenderDispatcher.java
+++ b/src/main/java/com/jozufozu/flywheel/backend/instancing/InstancedRenderDispatcher.java
@@ -18,11 +18,11 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.TickEvent;
 
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(Dist.CLIENT)

--- a/src/main/java/com/jozufozu/flywheel/config/FlwCommands.java
+++ b/src/main/java/com/jozufozu/flywheel/config/FlwCommands.java
@@ -2,6 +2,10 @@ package com.jozufozu.flywheel.config;
 
 import java.util.function.BiConsumer;
 
+import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.jozufozu.flywheel.backend.Backend;
@@ -16,8 +20,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraftforge.client.event.RegisterClientCommandsEvent;
-import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 
 public class FlwCommands {
 	public static void registerClientCommands(RegisterClientCommandsEvent event) {
@@ -88,7 +90,7 @@ public class FlwCommands {
 		commandBuilder.build(event.getDispatcher());
 	}
 
-	public static void booleanValueCommand(LiteralArgumentBuilder<CommandSourceStack> builder, ConfigValue<Boolean> value, BiConsumer<CommandSourceStack, Boolean> displayAction, BiConsumer<CommandSourceStack, Boolean> setAction) {
+	public static void booleanValueCommand(LiteralArgumentBuilder<CommandSourceStack> builder, ModConfigSpec.ConfigValue<Boolean> value, BiConsumer<CommandSourceStack, Boolean> displayAction, BiConsumer<CommandSourceStack, Boolean> setAction) {
 		builder
 			.executes(context -> {
 				displayAction.accept(context.getSource(), value.get());
@@ -127,7 +129,7 @@ public class FlwCommands {
 			command = Commands.literal(baseLiteral);
 		}
 
-		public <T extends ConfigValue<?>> void addValue(T value, String subcommand, BiConsumer<LiteralArgumentBuilder<CommandSourceStack>, T> consumer) {
+		public <T extends ModConfigSpec.ConfigValue<?>> void addValue(T value, String subcommand, BiConsumer<LiteralArgumentBuilder<CommandSourceStack>, T> consumer) {
 			LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(subcommand);
 			consumer.accept(builder, value);
 			command.then(builder);

--- a/src/main/java/com/jozufozu/flywheel/config/FlwConfig.java
+++ b/src/main/java/com/jozufozu/flywheel/config/FlwConfig.java
@@ -1,12 +1,11 @@
 package com.jozufozu.flywheel.config;
 
+import net.neoforged.neoforge.common.ModConfigSpec;
+
 import org.apache.commons.lang3.tuple.Pair;
 
-import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
-import net.minecraftforge.common.ForgeConfigSpec.EnumValue;
-import net.minecraftforge.fml.ModLoadingContext;
-import net.minecraftforge.fml.config.ModConfig;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.config.ModConfig;
 
 public class FlwConfig {
 
@@ -15,7 +14,7 @@ public class FlwConfig {
 	public final ClientConfig client;
 
 	public FlwConfig() {
-		Pair<ClientConfig, ForgeConfigSpec> client = new ForgeConfigSpec.Builder().configure(ClientConfig::new);
+		Pair<ClientConfig, ModConfigSpec> client = new ModConfigSpec.Builder().configure(ClientConfig::new);
 
 		this.client = client.getLeft();
 
@@ -43,11 +42,11 @@ public class FlwConfig {
 	}
 
 	public static class ClientConfig {
-		public final EnumValue<BackendType> backend;
-		public final BooleanValue debugNormals;
-		public final BooleanValue limitUpdates;
+		public final ModConfigSpec.EnumValue<BackendType> backend;
+		public final ModConfigSpec.BooleanValue debugNormals;
+		public final ModConfigSpec.BooleanValue limitUpdates;
 
-		public ClientConfig(ForgeConfigSpec.Builder builder) {
+		public ClientConfig(ModConfigSpec.Builder builder) {
 			backend = builder.comment("Select the backend to use.")
 					.defineEnum("backend", BackendType.INSTANCING);
 

--- a/src/main/java/com/jozufozu/flywheel/core/Contexts.java
+++ b/src/main/java/com/jozufozu/flywheel/core/Contexts.java
@@ -10,8 +10,8 @@ import com.jozufozu.flywheel.event.GatherContextEvent;
 import com.jozufozu.flywheel.util.ResourceUtil;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public class Contexts {

--- a/src/main/java/com/jozufozu/flywheel/core/Materials.java
+++ b/src/main/java/com/jozufozu/flywheel/core/Materials.java
@@ -8,8 +8,8 @@ import com.jozufozu.flywheel.core.materials.oriented.OrientedData;
 import com.jozufozu.flywheel.core.materials.oriented.OrientedType;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 public class Materials {

--- a/src/main/java/com/jozufozu/flywheel/core/PartialModel.java
+++ b/src/main/java/com/jozufozu/flywheel/core/PartialModel.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.client.event.ModelEvent;
+import net.neoforged.neoforge.client.event.ModelEvent;
 
 /**
  * A helper class for loading and accessing json models.

--- a/src/main/java/com/jozufozu/flywheel/core/StitchedSprite.java
+++ b/src/main/java/com/jozufozu/flywheel/core/StitchedSprite.java
@@ -9,7 +9,7 @@ import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
-import net.minecraftforge.client.event.TextureStitchEvent;
+import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
 
 public class StitchedSprite {
 	private static final Map<ResourceLocation, List<StitchedSprite>> ALL = new HashMap<>();
@@ -28,7 +28,7 @@ public class StitchedSprite {
 		this(InventoryMenu.BLOCK_ATLAS, location);
 	}
 
-	public static void onTextureStitchPost(TextureStitchEvent.Post event) {
+	public static void onTextureStitchPost(TextureAtlasStitchedEvent event) {
 		TextureAtlas atlas = event.getAtlas();
 		ResourceLocation atlasLocation = atlas.location();
 		List<StitchedSprite> sprites = ALL.get(atlasLocation);

--- a/src/main/java/com/jozufozu/flywheel/core/crumbling/CrumblingRenderer.java
+++ b/src/main/java/com/jozufozu/flywheel/core/crumbling/CrumblingRenderer.java
@@ -30,10 +30,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.BlockDestructionProgress;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
 
 /**
  * Responsible for rendering the block breaking overlay for instanced block entities.

--- a/src/main/java/com/jozufozu/flywheel/core/model/ModelUtil.java
+++ b/src/main/java/com/jozufozu/flywheel/core/model/ModelUtil.java
@@ -23,9 +23,9 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
-import net.minecraftforge.client.model.data.ModelData;
-import net.minecraftforge.client.model.data.ModelProperty;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.neoforged.fml.util.ObfuscationReflectionHelper;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.client.model.data.ModelProperty;
 
 public class ModelUtil {
 	/**

--- a/src/main/java/com/jozufozu/flywheel/core/model/WorldModelBuilder.java
+++ b/src/main/java/com/jozufozu/flywheel/core/model/WorldModelBuilder.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
-import net.minecraftforge.client.model.data.ModelData;
+import net.neoforged.neoforge.client.model.data.ModelData;
 
 public final class WorldModelBuilder implements Bufferable {
 	private final RenderType layer;

--- a/src/main/java/com/jozufozu/flywheel/core/virtual/VirtualRenderWorld.java
+++ b/src/main/java/com/jozufozu/flywheel/core/virtual/VirtualRenderWorld.java
@@ -21,6 +21,7 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.TickRateManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.flag.FeatureFlagSet;
@@ -367,6 +368,11 @@ public class VirtualRenderWorld extends Level implements FlywheelWorld {
 	@Nullable
 	public Entity getEntity(int id) {
 		return null;
+	}
+
+	@Override
+	public TickRateManager tickRateManager() {
+		return this.level.tickRateManager();
 	}
 
 	@Override

--- a/src/main/java/com/jozufozu/flywheel/event/BeginFrameEvent.java
+++ b/src/main/java/com/jozufozu/flywheel/event/BeginFrameEvent.java
@@ -4,7 +4,7 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.eventbus.api.Event;
+import net.neoforged.bus.api.Event;
 
 public class BeginFrameEvent extends Event {
 	private final ClientLevel world;

--- a/src/main/java/com/jozufozu/flywheel/event/EntityWorldHandler.java
+++ b/src/main/java/com/jozufozu/flywheel/event/EntityWorldHandler.java
@@ -3,11 +3,11 @@ package com.jozufozu.flywheel.event;
 import com.jozufozu.flywheel.backend.Backend;
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.event.entity.EntityJoinLevelEvent;
-import net.minecraftforge.event.entity.EntityLeaveLevelEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
+import net.neoforged.neoforge.event.entity.EntityLeaveLevelEvent;
 
 @Mod.EventBusSubscriber(Dist.CLIENT)
 public class EntityWorldHandler {

--- a/src/main/java/com/jozufozu/flywheel/event/ForgeEvents.java
+++ b/src/main/java/com/jozufozu/flywheel/event/ForgeEvents.java
@@ -6,19 +6,19 @@ import com.jozufozu.flywheel.light.LightUpdater;
 import com.jozufozu.flywheel.util.WorldAttached;
 
 import net.minecraft.client.Minecraft;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.level.LevelEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent;
+import net.neoforged.neoforge.event.TickEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 
 @Mod.EventBusSubscriber(Dist.CLIENT)
 public class ForgeEvents {
 
 	@SubscribeEvent
 	public static void addToDebugScreen(CustomizeGuiOverlayEvent.DebugText event) {
-		if (Minecraft.getInstance().options.renderDebug) {
+		if (Minecraft.getInstance().getDebugOverlay().showDebugScreen()) {
 			InstancedRenderDispatcher.getDebugString(event.getRight());
 		}
 	}

--- a/src/main/java/com/jozufozu/flywheel/event/GatherContextEvent.java
+++ b/src/main/java/com/jozufozu/flywheel/event/GatherContextEvent.java
@@ -1,7 +1,7 @@
 package com.jozufozu.flywheel.event;
 
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.fml.event.IModBusEvent;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.event.IModBusEvent;
 
 public class GatherContextEvent extends Event implements IModBusEvent {
 

--- a/src/main/java/com/jozufozu/flywheel/event/ReloadRenderersEvent.java
+++ b/src/main/java/com/jozufozu/flywheel/event/ReloadRenderersEvent.java
@@ -3,7 +3,7 @@ package com.jozufozu.flywheel.event;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraftforge.eventbus.api.Event;
+import net.neoforged.bus.api.Event;
 
 public class ReloadRenderersEvent extends Event {
 	private final ClientLevel world;

--- a/src/main/java/com/jozufozu/flywheel/event/RenderLayerEvent.java
+++ b/src/main/java/com/jozufozu/flywheel/event/RenderLayerEvent.java
@@ -2,6 +2,8 @@ package com.jozufozu.flywheel.event;
 
 import javax.annotation.Nullable;
 
+import net.neoforged.bus.api.Event;
+
 import org.joml.Matrix4f;
 
 import com.jozufozu.flywheel.backend.RenderLayer;
@@ -11,7 +13,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraftforge.eventbus.api.Event;
 
 public class RenderLayerEvent extends Event {
 	private final ClientLevel world;

--- a/src/main/java/com/jozufozu/flywheel/mixin/FrustumMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/FrustumMixin.java
@@ -1,5 +1,7 @@
 package com.jozufozu.flywheel.mixin;
 
+import net.neoforged.neoforge.common.NeoForge;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,7 +13,6 @@ import com.jozufozu.flywheel.event.BeginFrameEvent;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraftforge.common.MinecraftForge;
 
 @Mixin(Frustum.class)
 public class FrustumMixin {
@@ -19,7 +20,7 @@ public class FrustumMixin {
 	@Inject(method = "prepare", at = @At("TAIL"))
 	private void onPrepare(double x, double y, double z, CallbackInfo ci) {
 		if (ShadersModHandler.isRenderingShadowPass()) {
-			MinecraftForge.EVENT_BUS.post(new BeginFrameEvent(Minecraft.getInstance().level, LastActiveCamera.getActiveCamera(), (Frustum) (Object) this));
+			NeoForge.EVENT_BUS.post(new BeginFrameEvent(Minecraft.getInstance().level, LastActiveCamera.getActiveCamera(), (Frustum) (Object) this));
 		}
 	}
 }

--- a/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/LevelRendererMixin.java
@@ -1,5 +1,7 @@
 package com.jozufozu.flywheel.mixin;
 
+import net.neoforged.neoforge.common.NeoForge;
+
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -23,9 +25,8 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.common.MinecraftForge;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 @Mixin(value = LevelRenderer.class, priority = 1001) // Higher priority to go after sodium
@@ -39,19 +40,19 @@ public class LevelRendererMixin {
 
 	@Inject(at = @At("HEAD"), method = "setupRender")
 	private void setupRender(Camera camera, Frustum frustum, boolean queue, boolean isSpectator, CallbackInfo ci) {
-		MinecraftForge.EVENT_BUS.post(new BeginFrameEvent(level, camera, frustum));
+		NeoForge.EVENT_BUS.post(new BeginFrameEvent(level, camera, frustum));
 	}
 
-	@Inject(at = @At("TAIL"), method = "renderChunkLayer")
+	@Inject(at = @At("TAIL"), method = "renderSectionLayer")
 	private void renderLayer(RenderType type, PoseStack stack, double camX, double camY, double camZ, Matrix4f projection, CallbackInfo ci) {
-		MinecraftForge.EVENT_BUS.post(new RenderLayerEvent(level, type, stack, renderBuffers, camX, camY, camZ));
+		NeoForge.EVENT_BUS.post(new RenderLayerEvent(level, type, stack, renderBuffers, camX, camY, camZ));
 	}
 
 	@Inject(at = @At("TAIL"), method = "allChanged")
 	private void refresh(CallbackInfo ci) {
 		Backend.refresh();
 
-		MinecraftForge.EVENT_BUS.post(new ReloadRenderersEvent(level));
+		NeoForge.EVENT_BUS.post(new ReloadRenderersEvent(level));
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;checkPoseStack(Lcom/mojang/blaze3d/vertex/PoseStack;)V", ordinal = 2 // after the game renders the breaking overlay normally

--- a/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/InstanceAddMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/InstanceAddMixin.java
@@ -13,8 +13,8 @@ import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 
 @OnlyIn(Dist.CLIENT)
 @Mixin(LevelChunk.class)

--- a/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/SectionRebuildHooksMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/instancemanage/SectionRebuildHooksMixin.java
@@ -10,9 +10,9 @@ import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(targets = "net.minecraft.client.renderer.chunk.ChunkRenderDispatcher$RenderChunk$RebuildTask")
-public class ChunkRebuildHooksMixin {
-	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
+@Mixin(targets = "net.minecraft.client.renderer.chunk.SectionRenderDispatcher$RenderSection$RebuildTask")
+public class SectionRebuildHooksMixin {
+	@Inject(method = "handleBlockEntity(Lnet/minecraft/client/renderer/chunk/SectionRenderDispatcher$RenderSection$RebuildTask$CompileResults;Lnet/minecraft/world/level/block/entity/BlockEntity;)V", at = @At("HEAD"), cancellable = true)
 	private void flywheel$tryAddBlockEntity(@Coerce Object compileResults, BlockEntity blockEntity, CallbackInfo ci) {
 		if (InstancedRenderDispatcher.tryAddBlockEntity(blockEntity)) {
 			ci.cancel();

--- a/src/main/java/com/jozufozu/flywheel/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/sodium/ChunkBuilderMeshingTaskMixin.java
@@ -6,14 +6,14 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
 
-import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderMeshingTask;
+//import me.jellysquid.mods.sodium.client.render.chunk.compile.tasks.ChunkBuilderMeshingTask;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-@Mixin(value = ChunkBuilderMeshingTask.class, remap = false)
+//@Mixin(value = ChunkBuilderMeshingTask.class, remap = false)
 public class ChunkBuilderMeshingTaskMixin {
-	@Redirect(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderDispatcher;getRenderer(Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;", remap = true))
+	//@Redirect(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderDispatcher;getRenderer(Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;", remap = true))
 	private BlockEntityRenderer<?> flywheel$redirectGetRenderer(BlockEntityRenderDispatcher dispatcher, BlockEntity blockEntity) {
 		if (InstancedRenderDispatcher.tryAddBlockEntity(blockEntity)) {
 			return null;

--- a/src/main/java/com/jozufozu/flywheel/mixin/sodium/SodiumMixinPlugin.java
+++ b/src/main/java/com/jozufozu/flywheel/mixin/sodium/SodiumMixinPlugin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
 import com.google.common.base.Suppliers;
 
-import net.minecraftforge.fml.loading.LoadingModList;
+import net.neoforged.fml.loading.LoadingModList;
 
 public class SodiumMixinPlugin implements IMixinConfigPlugin {
 	private static final Supplier<Boolean> IS_SODIUM_LOADED = Suppliers.memoize(() -> LoadingModList.get().getModFileById("rubidium") != null);

--- a/src/main/java/com/jozufozu/flywheel/util/Mods.java
+++ b/src/main/java/com/jozufozu/flywheel/util/Mods.java
@@ -3,7 +3,7 @@ package com.jozufozu.flywheel.util;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import net.minecraftforge.fml.ModList;
+import net.neoforged.fml.ModList;
 
 /**
  * For compatibility with and without another mod present, we have to define load conditions of the specific code

--- a/src/main/java/com/jozufozu/flywheel/util/RenderMath.java
+++ b/src/main/java/com/jozufozu/flywheel/util/RenderMath.java
@@ -1,6 +1,6 @@
 package com.jozufozu.flywheel.util;
 
-import net.minecraftforge.client.model.lighting.QuadLighter;
+import net.neoforged.neoforge.client.model.lighting.QuadLighter;
 
 public class RenderMath {
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,12 +1,12 @@
 modLoader = "javafml"
-loaderVersion = "[47,)"
+loaderVersion = "${loader_version_range}"
 issueTrackerURL = "https://github.com/Jozufozu/Flywheel/issues"
 license = "MIT"
 
 [[mods]]
 modId = "flywheel"
 # The Implementation-Version property in the jar's MANIFEST.MF file will be used as the mod version at runtime
-version = "${file.jarVersion}"
+version = "${mod_version}"
 displayName = "Flywheel"
 logoFile = "logo.png"
 displayURL = "https://www.curseforge.com/minecraft/mc-mods/flywheel"
@@ -16,22 +16,22 @@ description = '''
 A modern engine for modded minecraft.'''
 
 [[dependencies.flywheel]]
-modId = "forge"
-mandatory = true
-versionRange = "[47.0.0,)"
+modId = "neoforge"
+type = "required"
+versionRange = "${neoforge_version_range}"
 ordering = "NONE"
 side = "CLIENT"
 
 [[dependencies.flywheel]]
 modId = "minecraft"
-mandatory = true
-versionRange = "[1.20.1,1.21)"
+type = "required"
+versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "CLIENT"
 
 [[dependencies.flywheel]]
 modId = "rubidium"
-mandatory = false
+type = "optional"
 versionRange = "[0.7.0,)"
 ordering = "NONE"
 side = "CLIENT"

--- a/src/main/resources/flywheel.mixins.json
+++ b/src/main/resources/flywheel.mixins.json
@@ -21,7 +21,7 @@
     "RenderTypeMixin",
     "fix.FixFabulousDepthMixin",
     "fix.FixNormalScalingMixin",
-    "instancemanage.ChunkRebuildHooksMixin",
+    "instancemanage.SectionRebuildHooksMixin",
     "instancemanage.InstanceAddMixin",
     "instancemanage.InstanceRemoveMixin",
     "instancemanage.InstanceUpdateMixin",


### PR DESCRIPTION
This PR replaces Forge with NeoForge and updates to 1.20.4

- The MixinGradle plugin has been replaced with the NeoGradle mixin plugin
- Librarian is no longer required as NeoForge natively supports parchment
- DistExecutor is deprecated and has been replaced with FMLEnvironment.dist
- FMLJavaModLoadingContext is deprecated, the mod event bus can now be obtained from a constructor parameter
- Oculus and Rubidium don't support 1.20.4 yet, so their dependencies and parts of their code have been commented out