### PR TITLE
Fix neoforge specific mixin config for vanillin not being registered

### DIFF
--- a/vanillinNeoForge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/vanillinNeoForge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,6 +16,8 @@ displayTest = "IGNORE_ALL_VERSION"
 
 [[mixins]]
 config = "vanillin.mixins.json"
+[[mixins]]
+config = "vanillin.neoforge.mixins.json"
 
 [[dependencies.${ vanillin_id }]]
 modId = "minecraft"


### PR DESCRIPTION
- Fixes #293