### PR TITLE
Use weakKeys for LevelAttached to prevent leaking levels

### DIFF
--- a/common/src/lib/java/dev/engine_room/flywheel/lib/util/LevelAttached.java
+++ b/common/src/lib/java/dev/engine_room/flywheel/lib/util/LevelAttached.java
@@ -24,6 +24,7 @@ public final class LevelAttached<T> {
 		ALL.add(thisRef);
 
 		cache = CacheBuilder.newBuilder()
+				.weakKeys() // This prevents Levels from being leaked if invalidateLevel isn't called for them, usually in level wrapper cases
 				.<LevelAccessor, T>removalListener(n -> finalizer.accept(n.getValue()))
 				.build(new CacheLoader<>() {
 					@Override


### PR DESCRIPTION
Fixes https://github.com/Creators-of-Create/Create/issues/9858